### PR TITLE
fix: stars badge showing INVALID (add cacheSeconds=86400)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ### The only opportunity list built for college freshmen & sophomores.
 
-[![Stars](https://img.shields.io/github/stars/Jose-Gael-Cruz-Lopez/underclassmen-opportunities?style=for-the-badge&color=FFD700&labelColor=000000)](https://github.com/Jose-Gael-Cruz-Lopez/underclassmen-opportunities/stargazers)
+[![Stars](https://img.shields.io/github/stars/Jose-Gael-Cruz-Lopez/underclassmen-opportunities?style=for-the-badge&color=FFD700&labelColor=000000&cacheSeconds=86400)](https://github.com/Jose-Gael-Cruz-Lopez/underclassmen-opportunities/stargazers)
 [![Last Updated](https://img.shields.io/github/last-commit/Jose-Gael-Cruz-Lopez/underclassmen-opportunities?style=for-the-badge&label=Last%20Updated&color=00C853&labelColor=000000)](https://github.com/Jose-Gael-Cruz-Lopez/underclassmen-opportunities/commits/main)
 [![Contributors](https://img.shields.io/github/contributors/Jose-Gael-Cruz-Lopez/underclassmen-opportunities?style=for-the-badge&color=0091EA&labelColor=000000)](https://github.com/Jose-Gael-Cruz-Lopez/underclassmen-opportunities/graphs/contributors)
 [![Open Issues](https://img.shields.io/github/issues/Jose-Gael-Cruz-Lopez/underclassmen-opportunities?style=for-the-badge&label=Submissions&color=FF6D00&labelColor=000000)](https://github.com/Jose-Gael-Cruz-Lopez/underclassmen-opportunities/issues)


### PR DESCRIPTION
## Summary

The Stars badge at the top of the README was rendering as **STARS: INVALID** instead of the actual count (163 as of today). This is a known [shields.io](https://shields.io) failure mode: when shields.io's free-tier cache misses on the GitHub stars endpoint and the unauthenticated GitHub API rate limit is hit, shields.io falls back to displaying \"INVALID\".

## Fix

Append \`&cacheSeconds=86400\` to the badge URL so shields.io caches the response for 24 hours, sidestepping the rate limit:

\`\`\`diff
-![Stars](https://img.shields.io/github/stars/Jose-Gael-Cruz-Lopez/underclassmen-opportunities?style=for-the-badge&color=FFD700&labelColor=000000)
+![Stars](https://img.shields.io/github/stars/Jose-Gael-Cruz-Lopez/underclassmen-opportunities?style=for-the-badge&color=FFD700&labelColor=000000&cacheSeconds=86400)
\`\`\`

## Verification

Confirmed via direct \`curl\` of the new URL:
- **Before:** \`<title>STARS: INVALID</title>\`
- **After:** SVG renders \"163\" (matches GitHub API: \`stargazers_count: 163\`)

Star counts don't change minute-to-minute, so a 24h cache window is fine.

## Test plan

- [ ] Refresh the rendered README on GitHub — badge should show the actual star count instead of \"INVALID\".

🤖 Generated with [Claude Code](https://claude.com/claude-code)