### PR TITLE
docs: add Canada student jobs resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,7 +294,7 @@ State-specific scholarships, grants, and aid programs for underclassmen and risi
 - [Interview-Guidance](https://sophiasun.substack.com/s/interviews)
 - [Building Projects Without Experience](https://github.com/codecrafters-io/build-your-own-x)
 - [LeetCode Beginner Guide](https://leetcode.com/explore/)
-- [Hanzilla Jobs — Canada student internships](https://jobs.hanzilla.co/internships/) — daily-updated Canadian student/recent-grad board for internships, co-ops, new grad, junior, and entry-level roles across tech, finance, engineering, business, sciences, and more
+- [Hanzilla Jobs (Canada)](https://jobs.hanzilla.co/internships/) — daily-updated Canadian student jobs board for internships, co-ops, and entry-level roles
 - [Archived / Closed Opportunities](ARCHIVE.md) — past programs that may reopen next cycle
 
 ---

--- a/README.md
+++ b/README.md
@@ -294,6 +294,7 @@ State-specific scholarships, grants, and aid programs for underclassmen and risi
 - [Interview-Guidance](https://sophiasun.substack.com/s/interviews)
 - [Building Projects Without Experience](https://github.com/codecrafters-io/build-your-own-x)
 - [LeetCode Beginner Guide](https://leetcode.com/explore/)
+- [Hanzilla Jobs — Canada student internships](https://jobs.hanzilla.co/internships/) — daily-updated Canadian student/recent-grad board for internships, co-ops, new grad, junior, and entry-level roles across tech, finance, engineering, business, sciences, and more
 - [Archived / Closed Opportunities](ARCHIVE.md) — past programs that may reopen next cycle
 
 ---


### PR DESCRIPTION
## Summary
- Adds Hanzilla Jobs to the Resources for Underclassmen section as a Canada-specific student internship/co-op resource.
- Uses the internships deep link instead of the homepage so Canadian students land directly on relevant early-career roles.

## Context
Hanzilla Jobs is a free, daily-updated Canadian student/recent-grad jobs board covering internships, co-ops, new grad, junior, and entry-level roles across tech, finance, engineering, business, sciences, and more.

Disclosure: I’m the builder of Hanzilla Jobs. I thought it may be useful as a companion resource for Canadian underclassmen who use this list.
