### PR TITLE
Remove dead oosmetrics badge from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@
 [![Last Updated](https://img.shields.io/github/last-commit/Jose-Gael-Cruz-Lopez/underclassmen-opportunities?style=for-the-badge&label=Last%20Updated&color=00C853&labelColor=000000)](https://github.com/Jose-Gael-Cruz-Lopez/underclassmen-opportunities/commits/main)
 [![Contributors](https://img.shields.io/github/contributors/Jose-Gael-Cruz-Lopez/underclassmen-opportunities?style=for-the-badge&color=0091EA&labelColor=000000)](https://github.com/Jose-Gael-Cruz-Lopez/underclassmen-opportunities/graphs/contributors)
 [![Open Issues](https://img.shields.io/github/issues/Jose-Gael-Cruz-Lopez/underclassmen-opportunities?style=for-the-badge&label=Submissions&color=FF6D00&labelColor=000000)](https://github.com/Jose-Gael-Cruz-Lopez/underclassmen-opportunities/issues)
-[![oosmetrics](https://api.oosmetrics.com/api/v1/badge/achievement/9c7372b6-b00d-4295-b86c-3e2a122c66fb.svg)](https://oosmetrics.com/repo/Jose-Gael-Cruz-Lopez/underclassmen-opportunities)
 
 </div>
 


### PR DESCRIPTION
## What

Removes the `oosmetrics` badge from the README header.

## Why

The `api.oosmetrics.com` (and root `oosmetrics.com`) domain no longer resolves — DNS returns `SERVFAIL` — so the badge rendered as a broken image icon in the header. Removing it aligns the badge row with the sibling `fromcampustocareer-opportunities` repo (Stars · Last Updated · Contributors · Submissions).

Note: the intermittent "INVALID" text on the Stars/Contributors/etc. badges is unrelated — that's shields.io's shared unauthenticated GitHub API quota getting rate-limited, which flickers on any GitHub badge and is not a repo-specific bug.

## Test

- `nslookup oosmetrics.com` / `nslookup api.oosmetrics.com` → `SERVFAIL` (dead domain)
- `grep oosmetrics README.md` → no matches after the change

🤖 Generated with [Claude Code](https://claude.com/claude-code)