### PR TITLE
Fix stuck INVALID stars badge (drop cacheSeconds=86400)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ### The only opportunity list built for college freshmen & sophomores.
 
-[![Stars](https://img.shields.io/github/stars/Jose-Gael-Cruz-Lopez/underclassmen-opportunities?style=for-the-badge&color=FFD700&labelColor=000000&cacheSeconds=86400)](https://github.com/Jose-Gael-Cruz-Lopez/underclassmen-opportunities/stargazers)
+[![Stars](https://img.shields.io/github/stars/Jose-Gael-Cruz-Lopez/underclassmen-opportunities?style=for-the-badge&color=FFD700&labelColor=000000)](https://github.com/Jose-Gael-Cruz-Lopez/underclassmen-opportunities/stargazers)
 [![Last Updated](https://img.shields.io/github/last-commit/Jose-Gael-Cruz-Lopez/underclassmen-opportunities?style=for-the-badge&label=Last%20Updated&color=00C853&labelColor=000000)](https://github.com/Jose-Gael-Cruz-Lopez/underclassmen-opportunities/commits/main)
 [![Contributors](https://img.shields.io/github/contributors/Jose-Gael-Cruz-Lopez/underclassmen-opportunities?style=for-the-badge&color=0091EA&labelColor=000000)](https://github.com/Jose-Gael-Cruz-Lopez/underclassmen-opportunities/graphs/contributors)
 [![Open Issues](https://img.shields.io/github/issues/Jose-Gael-Cruz-Lopez/underclassmen-opportunities?style=for-the-badge&label=Submissions&color=FF6D00&labelColor=000000)](https://github.com/Jose-Gael-Cruz-Lopez/underclassmen-opportunities/issues)


### PR DESCRIPTION
## What

Removes `&cacheSeconds=86400` from the **Stars** shields.io badge in the README header. Single-line change.

## Why it was stuck on INVALID

The Stars badge was the **only** badge carrying `cacheSeconds=86400`. shields.io's GitHub badges share one unauthenticated GitHub API quota, so any of them can momentarily return `invalid` when that quota is rate-limited. For the other three badges that blip clears within minutes (short default cache). For Stars, the long `max-age=86400` pinned the broken image in GitHub's camo/CDN cache for up to **24 hours**, so it stayed INVALID while the others self-healed.

## Verification

- Cache-busted request to the Stars endpoint returns the real value: **291 stars** (`>291<` in the SVG, HTTP 200, no "invalid").
- GitHub API ground truth: `"stargazers_count": 291`; local unauth quota was not exhausted (58 remaining) — confirming the INVALID was a stale cache, not bad data.

## Effect

Matches the other three badges (no `cacheSeconds`), and the URL change makes GitHub's camo proxy re-fetch a fresh image immediately on merge. Prevents future 24h "stuck INVALID" episodes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)