### PR TITLE
fix: header badges (shields.io outage) → badgen.net

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@
 
 ### The only opportunity list built for college freshmen & sophomores.
 
-[![Stars](https://img.shields.io/github/stars/Jose-Gael-Cruz-Lopez/underclassmen-opportunities?style=for-the-badge&color=FFD700&labelColor=000000)](https://github.com/Jose-Gael-Cruz-Lopez/underclassmen-opportunities/stargazers)
-[![Last Updated](https://img.shields.io/github/last-commit/Jose-Gael-Cruz-Lopez/underclassmen-opportunities?style=for-the-badge&label=Last%20Updated&color=00C853&labelColor=000000)](https://github.com/Jose-Gael-Cruz-Lopez/underclassmen-opportunities/commits/main)
-[![Contributors](https://img.shields.io/github/contributors/Jose-Gael-Cruz-Lopez/underclassmen-opportunities?style=for-the-badge&color=0091EA&labelColor=000000)](https://github.com/Jose-Gael-Cruz-Lopez/underclassmen-opportunities/graphs/contributors)
-[![Open Issues](https://img.shields.io/github/issues/Jose-Gael-Cruz-Lopez/underclassmen-opportunities?style=for-the-badge&label=Submissions&color=FF6D00&labelColor=000000)](https://github.com/Jose-Gael-Cruz-Lopez/underclassmen-opportunities/issues)
+[![Stars](https://badgen.net/github/stars/Jose-Gael-Cruz-Lopez/underclassmen-opportunities?label=Stars&color=FFD700&labelColor=000000)](https://github.com/Jose-Gael-Cruz-Lopez/underclassmen-opportunities/stargazers)
+[![Last Updated](https://badgen.net/github/last-commit/Jose-Gael-Cruz-Lopez/underclassmen-opportunities?label=Last%20Updated&color=00C853&labelColor=000000)](https://github.com/Jose-Gael-Cruz-Lopez/underclassmen-opportunities/commits/main)
+[![Contributors](https://badgen.net/github/contributors/Jose-Gael-Cruz-Lopez/underclassmen-opportunities?label=Contributors&color=0091EA&labelColor=000000)](https://github.com/Jose-Gael-Cruz-Lopez/underclassmen-opportunities/graphs/contributors)
+[![Open Issues](https://badgen.net/github/open-issues/Jose-Gael-Cruz-Lopez/underclassmen-opportunities?label=Submissions&color=FF6D00&labelColor=000000)](https://github.com/Jose-Gael-Cruz-Lopez/underclassmen-opportunities/issues)
 
 </div>
 


### PR DESCRIPTION
### Problem
The header badges render **"UNABLE TO SELECT NEXT GITHUB TOKEN FROM POOL"** instead of stats.

This is a **shields.io-side outage**, not a markup issue — shields.io's shared GitHub API token pool is exhausted, which breaks *every* `img.shields.io/github/*` badge globally (verified: `facebook/react`'s star badge errors too). It has not recovered on its own over the past while.

### Fix
Switch the four badges from `img.shields.io/github/*` to **`badgen.net/github/*`**, which runs on separate infrastructure and is currently serving live values:

| Badge | Value (now) |
|---|---|
| Stars | 642 |
| Last Updated | ~1 hour ago |
| Contributors | 5 |
| Submissions (open issues) | 15 |

Labels (`Stars`, `Last Updated`, `Contributors`, `Submissions`), hex colors (`FFD700` / `00C853` / `0091EA` / `FF6D00`), black label backgrounds, and all click-through link targets are preserved.

### Note on style
badgen has no `for-the-badge` style, so the badges render in badgen's flatter classic style rather than the large blocky look. If/when shields.io stabilizes and the bold `for-the-badge` look is preferred, this is a one-line-per-badge revert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)