### PR TITLE
fix: weekly digest claims a 7-day closing window; the badge bot uses 14

### DIFF
--- a/.github/scripts/closing_soon.py
+++ b/.github/scripts/closing_soon.py
@@ -26,6 +26,7 @@ CLOSING = "🔥 **[CLOSING SOON]**"
 
 # Deadlines this many days out (or fewer) get the 🔥 badge.
 # Keep in sync with the weekly audit runbook, which uses the same window.
+# weekly_digest.py imports this constant for its "closing soon" copy.
 CLOSING_SOON_DAYS = 14
 
 MONTHS = (

--- a/.github/scripts/weekly_digest.py
+++ b/.github/scripts/weekly_digest.py
@@ -15,6 +15,8 @@ import re
 from datetime import datetime, timedelta
 from zoneinfo import ZoneInfo
 
+from closing_soon import CLOSING_SOON_DAYS
+
 PST = ZoneInfo("America/Los_Angeles")
 README = os.path.join(os.path.dirname(__file__), "..", "..", "README.md")
 DIGEST = os.path.join(os.path.dirname(__file__), "..", "..", "digest.md")
@@ -136,7 +138,7 @@ def main():
 
     if closing_rows:
         out.append(f"\n## 🔥 Closing soon ({len(closing_rows)})\n")
-        out.append("Apply now — these deadlines are within 7 days:\n")
+        out.append(f"Apply now — these deadlines are within {CLOSING_SOON_DAYS} days:\n")
         for s, r in closing_rows:
             out.append(build_row_summary(s, r))
 


### PR DESCRIPTION
## Summary

The weekly digest's "Closing soon" section says **"Apply now — these deadlines are within 7 days"**, but the 🔥 [CLOSING SOON] flag it reports is set by `closing_soon.py` with `CLOSING_SOON_DAYS = 14` — the window was widened to 14 days in 3e21cc4 and the digest copy never followed. Readers see deadlines up to two weeks out under a "within 7 days" heading (e.g. the Aug 10 digest listed Aug 21–28 deadlines there).

## Fix

- `weekly_digest.py` now imports `CLOSING_SOON_DAYS` from `closing_soon.py` and interpolates it into the copy, so the two can't drift again.
- Added a note next to the constant in `closing_soon.py` pointing out the digest imports it.

The "New this week / last 7 days" section is untouched — that window is genuinely weekly and correct.

## Verification

Ran `python .github/scripts/weekly_digest.py` locally (same invocation as `weekly_digest.yml:24`, which also confirms the sibling-module import resolves): digest generates cleanly with **"Apply now — these deadlines are within 14 days:"** — 12 closing-soon and 9 new entries against current `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)